### PR TITLE
fix: Dynamic BLE characteristic UUID discovery for multi-device support

### DIFF
--- a/custom_components/istrip/config_flow.py
+++ b/custom_components/istrip/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.components.bluetooth import (
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
 
-from .const import DOMAIN
+from .const import DOMAIN, KNOWN_CHAR_UUIDS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ class IstripConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle Bluetooth discovery."""
         self._discovery_info = discovery_info
+        self._char_uuid = await self._discover_char_uuid(discovery_info.address)
         return await self.async_step_bluetooth_confirm()
 
     async def async_step_user(
@@ -128,6 +129,7 @@ class IstripConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.debug("Connected, accessing services")
 
                 services = client.services
+                writable_uuids: list[str] = []
 
                 for service in services:
                     for char in service.characteristics:
@@ -140,7 +142,23 @@ class IstripConfigFlow(ConfigFlow, domain=DOMAIN):
                             "write" in char.properties
                             or "write-without-response" in char.properties
                         ):
-                            return str(char.uuid)
+                            writable_uuids.append(str(char.uuid))
+
+                # Prioritize known iStrip characteristic UUIDs
+                for known_uuid in KNOWN_CHAR_UUIDS:
+                    if known_uuid in writable_uuids:
+                        _LOGGER.debug(
+                            "Found known characteristic UUID: %s", known_uuid
+                        )
+                        return known_uuid
+
+                # Fall back to the first writable characteristic
+                if writable_uuids:
+                    _LOGGER.debug(
+                        "Using first writable characteristic: %s", writable_uuids[0]
+                    )
+                    return writable_uuids[0]
+
             finally:
                 await client.disconnect()
         except Exception:

--- a/custom_components/istrip/const.py
+++ b/custom_components/istrip/const.py
@@ -3,3 +3,10 @@
 from __future__ import annotations
 
 DOMAIN = "istrip"
+
+# Known writable characteristic UUIDs used by iStrip-compatible devices.
+# Different lamps may use different UUIDs (see GitHub issue #14).
+KNOWN_CHAR_UUIDS = [
+    "0000ae01-0000-1000-8000-00805f9b34fb",
+    "0000ac52-1212-efde-1523-785fedbeda25",
+]

--- a/custom_components/istrip/light.py
+++ b/custom_components/istrip/light.py
@@ -21,7 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, KNOWN_CHAR_UUIDS
 from .payload_generator import PayloadGenerator
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up iStrip light from config entry."""
     address: str = entry.data["address"]
-    char_uuid: str = entry.data["char_uuid"]
+    char_uuid: str | None = entry.data.get("char_uuid")
     name: str = entry.data.get("name", "iStrip")
     async_add_entities([IstripLight(address, char_uuid, name, entry.entry_id)])
 
@@ -52,7 +52,7 @@ class IstripLight(LightEntity):
     def __init__(
         self,
         address: str,
-        char_uuid: str,
+        char_uuid: str | None,
         name: str,
         entry_id: str,
     ) -> None:
@@ -191,6 +191,21 @@ class IstripLight(LightEntity):
             self._connected = True
             _LOGGER.debug("Connected to iStrip device at %s", self._address)
 
+            # If char_uuid was not discovered during setup, find it now
+            if not self._char_uuid:
+                self._char_uuid = self._discover_char_uuid_from_services()
+                if not self._char_uuid:
+                    _LOGGER.error(
+                        "No writable characteristic found on %s", self._address
+                    )
+                    await self._disconnect()
+                    return
+                _LOGGER.info(
+                    "Discovered characteristic UUID %s on %s",
+                    self._char_uuid,
+                    self._address,
+                )
+
             try:
                 await self._client.start_notify(
                     self._char_uuid, self._handle_notification
@@ -205,6 +220,26 @@ class IstripLight(LightEntity):
             _LOGGER.error("Failed to connect to device at %s", self._address)
             self._connected = False
             self._client = None
+
+    def _discover_char_uuid_from_services(self) -> str | None:
+        """Find the best writable characteristic UUID from the connected client."""
+        if not self._client or not self._client.is_connected:
+            return None
+
+        writable_uuids: list[str] = []
+        for service in self._client.services:
+            for char in service.characteristics:
+                if (
+                    "write" in char.properties
+                    or "write-without-response" in char.properties
+                ):
+                    writable_uuids.append(str(char.uuid))
+
+        for known_uuid in KNOWN_CHAR_UUIDS:
+            if known_uuid in writable_uuids:
+                return known_uuid
+
+        return writable_uuids[0] if writable_uuids else None
 
     async def _disconnect(self) -> None:
         """Disconnect from the BLE device."""


### PR DESCRIPTION
## Summary

Fixes #14 — Some iStrip-compatible lamps (e.g. **Quigo Sunset Lamp** `SSL-*`) use BLE characteristic UUID `0000ac52-1212-efde-1523-785fedbeda25` instead of the typical `0000ae01-0000-1000-8000-00805f9b34fb`. The lamp silently ignores writes to the wrong UUID, making it appear unresponsive.

## Root Cause

The Bluetooth auto-discovery flow (`async_step_bluetooth`) was **not calling `_discover_char_uuid()`**, so `char_uuid` was stored as `None` in the config entry. Additionally, the UUID discovery logic returned the first writable characteristic found, which may not be the correct control characteristic on all devices.

## Changes

### `const.py`
- Added `KNOWN_CHAR_UUIDS` — a list of known writable characteristic UUIDs used by iStrip-compatible devices. Easily extensible as new device variants are discovered.

### `config_flow.py`
- **`async_step_bluetooth`** now calls `_discover_char_uuid()` so Bluetooth auto-discovered devices get the correct characteristic UUID probed at setup time.
- **`_discover_char_uuid`** now collects all writable characteristics and **prioritizes known iStrip UUIDs** before falling back to the first writable one. This ensures the correct control characteristic is selected on devices that expose multiple writable characteristics.

### `light.py`
- `char_uuid` is now typed as `str | None` to handle existing config entries that were created without UUID discovery.
- **`_ensure_connected`** performs **runtime UUID discovery** via `_discover_char_uuid_from_services()` when the stored `char_uuid` is `None`. This acts as a migration path for existing config entries — no manual reconfiguration needed.
- Added `_discover_char_uuid_from_services()` — probes the connected client's services using the same known-UUID-first strategy.

## Backward Compatibility

- Existing config entries with a valid `char_uuid` continue to work unchanged.
- Existing entries with a `None` `char_uuid` (from the broken Bluetooth discovery path) are automatically healed at connection time.
- No config entry schema migration required.

## Tested Devices

| Device | BLE Name | Characteristic UUID |
|--------|----------|-------------------|
| Original iStrip+ | Various | `0000ae01-0000-1000-8000-00805f9b34fb` |
| Quigo Sunset Lamp | `SSL-*` | `0000ac52-1212-efde-1523-785fedbeda25` |
